### PR TITLE
Updated CI workflows for macOS, Ubuntu and CentOS

### DIFF
--- a/.github/workflows/centos-system-ci.yml
+++ b/.github/workflows/centos-system-ci.yml
@@ -32,6 +32,7 @@ jobs:
         if [ "${{ github.event_name }}" = "schedule" ]; then
           echo "GHA_BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
+        echo "GHA_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
 
     - name: Set OSVERS
       run: |
@@ -62,7 +63,7 @@ jobs:
       run: |
         yum update -y
         yum install -y sudo curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
+        curl https://raw.githubusercontent.com/${GHA_REPOSITORY}/${GHA_BRANCH_NAME}/util/install | bash
         # remove whole BioDynaMo repository to catch errors related to paths pointing into the build dir
         mktemp -d
         find /tmp -iname biodynamo -type d || true

--- a/.github/workflows/macos-system-ci.yml
+++ b/.github/workflows/macos-system-ci.yml
@@ -33,7 +33,7 @@ jobs:
         sudo ln -s /Applications/Xcode_14.2.app /Applications/Xcode.app
         sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
       if: matrix.os == 'macos-12'
-    
+
     - name: Make sure Xcode 15.2 is used on macOS 13 as the default /Application/Xcode.app
       shell: bash
       run: |
@@ -53,12 +53,14 @@ jobs:
         if [ "${{ github.event_name }}" = "schedule" ]; then
           echo "GHA_BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
-    
+
+        echo "GHA_REPOSITORY=${{ github.repository}}" >> $GITHUB_ENV
+
     - name: Install BioDynaMo
       shell: zsh {0}
       run: |
         brew install curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
+        curl https://raw.githubusercontent.com/${GHA_REPOSITORY}/${GHA_BRANCH_NAME}/util/install | bash
         # remove whole bidynamo repository to catch errors related to paths pointing into the build dir
         mktemp -d
         find /tmp -iname biodynamo -type d || true
@@ -102,7 +104,7 @@ jobs:
         cmake --build build --parallel --config Release
 
     # Don't do this in the `Build BioDynaMo step`, because notebooks might time out in GHA
-    # runners, while waiting for other targets to be compiled. Run notebooks only on 
+    # runners, while waiting for other targets to be compiled. Run notebooks only on
     # macOS 10.15 until we managed to compile ROOT for 11.6 again.
     - name: Run notebooks
       shell: zsh {0}

--- a/.github/workflows/ubuntu-system-ci.yml
+++ b/.github/workflows/ubuntu-system-ci.yml
@@ -34,6 +34,8 @@ jobs:
           echo "GHA_BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
 
+        echo "GHA_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
+
     - name: Set OSVERS
       run: |
         ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
@@ -55,7 +57,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y curl
-        curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/${GHA_BRANCH_NAME}/util/install | bash
+        curl https://raw.githubusercontent.com/${GHA_REPOSITORY}/${GHA_BRANCH_NAME}/util/install | bash
         # remove whole bidynamo repository to catch errors related to paths pointing into the build dir
         mktemp -d
         find /tmp -iname biodynamo -type d || true
@@ -133,7 +135,7 @@ jobs:
           -B build
         cmake --build build --parallel --config Release --target notebooks  -- -j1
       if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-22.04'
-      
+
 
     - name: Build BioDynaMo
       shell: bash

--- a/util/install
+++ b/util/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Adapted from https://github.com/pyenv/pyenv-installer/
-# Usage: curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/master/util/install | bash 
+# Usage: curl https://raw.githubusercontent.com/BioDynaMo/biodynamo/master/util/install | bash
 
 set -e
 
@@ -8,7 +8,7 @@ if [ -z ${BDM_INSTALL} ]; then
   export BDM_INSTALL=v1.04-patches
 fi
 echo "BDM_INSTALL is set to: $BDM_INSTALL"
-  
+
 temp_dir=$(mktemp -d)
 BDM_SRC="${temp_dir}/biodynamo"
 mkdir "$BDM_SRC"
@@ -34,8 +34,9 @@ FailedCheckout() {
 
 Checkout() {
   # In Github Actions we checkout the branch that is running the install script
+  REPO_URL="${GITHUB}/${GHA_REPOSITORY}.git"
   if [ ! -z ${GITHUB_ACTIONS+x} ]; then
-    git clone --branch ${GHA_BRANCH_NAME} "$1" . || FailedClone "$1"
+    git clone --branch ${GHA_BRANCH_NAME} "$REPO_URL" . || FailedClone "$REPO_URL"
   else
     git clone "$1" . || FailedClone "$1"
     git checkout "$BDM_INSTALL" || FailedCheckout "$BDM_INSTALL"


### PR DESCRIPTION
- Added GHA_REPOSITORY environment variable
- Modified the curl command to use the GHA_REPOSITORY variable
- Modified Checkout() to use ${GITHUB}/${GHA_REPOSITORY}.git when running in GitHub Actions.
- Maintained the original behavior for non-GitHub Actions contexts by using the provided argument.